### PR TITLE
Add MVP skeleton with FastAPI runner hooks and challenges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+__pycache__/
+.env
+*.pyc

--- a/README-cursor.md
+++ b/README-cursor.md
@@ -1,0 +1,169 @@
+# SP33D C0D3R 🚀
+
+A competitive coding platform that measures and tracks your coding speed while solving algorithmic challenges. Race against the clock, track your performance, and compete with others in real-time coding challenges.
+
+## 🎯 What is SP33D C0D3R?
+
+SP33D C0D3R is a web-based coding competition platform that:
+
+- **Measures coding speed** - Tracks time from challenge start to successful completion
+- **Provides real-time feedback** - Run tests instantly and see results immediately
+- **Tracks assistance usage** - Monitors copy-paste events and character counts
+- **Supports multiple challenges** - Currently includes FizzBuzz and Two Sum challenges
+- **Secure execution** - Runs code in isolated Docker containers with resource limits
+
+## 🏗️ Architecture
+
+The project consists of several components:
+
+- **Frontend**: Next.js web application with Monaco Editor for code editing
+- **Backend API**: FastAPI service for managing users, runs, and challenge execution
+- **Database**: PostgreSQL for storing user data, run results, and performance metrics
+- **Code Runner**: Docker-based Python execution environment with security constraints
+- **Challenges**: Algorithmic problems with test suites and starter code
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Git
+
+### Installation
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd SP33D-C0D3R
+   ```
+
+2. **Start the services**
+   ```bash
+   docker-compose up -d
+   ```
+
+3. **Access the application**
+   - Web UI: http://localhost:3000
+   - API: http://localhost:8000
+   - Database: localhost:5432
+
+## 🎮 How to Use
+
+### Starting a Challenge
+
+1. Navigate to a challenge (e.g., `/challenge/fizzbuzz`)
+2. The timer starts automatically when you begin
+3. Write your solution in the Monaco code editor
+4. Click "Run tests" to execute your code
+5. View test results and logs in real-time
+6. Complete the challenge to see your final time!
+
+### Available Challenges
+
+#### FizzBuzz
+Write a function that returns a list from 1 to n where:
+- Multiples of 3 are replaced with "Fizz"
+- Multiples of 5 are replaced with "Buzz"
+- Multiples of both are replaced with "FizzBuzz"
+- Other numbers remain as integers
+
+#### Two Sum
+Given a list of integers and a target sum, return the indices of two numbers that add up to the target. Return indices in ascending order.
+
+## 🔧 Development
+
+### Project Structure
+
+```
+SP33D-C0D3R/
+├── api/                 # FastAPI backend service
+├── challenges/          # Coding challenge definitions
+├── infra/              # Database initialization
+├── runner/             # Code execution environment
+├── web/                # Next.js frontend application
+└── docker-compose.yml  # Service orchestration
+```
+
+### Adding New Challenges
+
+1. Create a new directory in `challenges/`
+2. Add a `manifest.yaml` file with challenge metadata
+3. Create a `prompt.md` with the problem description
+4. Provide `starter.py` with initial code template
+5. Add test files in `tests_public/` and `tests_hidden/`
+
+### Local Development
+
+```bash
+# Start only specific services
+docker-compose up db api
+
+# View logs
+docker-compose logs -f api
+
+# Rebuild services
+docker-compose build web
+```
+
+## 🛡️ Security Features
+
+- **Container isolation**: Code runs in isolated Docker containers
+- **Resource limits**: 512MB memory limit per execution
+- **Network disabled**: Containers cannot access external networks
+- **Read-only mounts**: Challenge files are mounted as read-only
+
+## 📊 Performance Tracking
+
+The platform tracks various metrics:
+- **Completion time**: From start to successful test pass
+- **Attempt count**: Number of test runs
+- **Assistance usage**: Copy-paste events and character counts
+- **Code execution logs**: Test results and error messages
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+**Service won't start**: Ensure Docker is running and ports 3000, 8000, and 5432 are available
+
+**Database connection errors**: Wait for PostgreSQL to fully initialize, or restart the db service
+
+**Code execution fails**: Check that the runner container built successfully and Docker socket is accessible
+
+### Logs and Debugging
+
+```bash
+# View all service logs
+docker-compose logs
+
+# View specific service logs
+docker-compose logs api
+
+# Access database directly
+docker-compose exec db psql -U speed -d speed
+```
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests for new functionality
+5. Submit a pull request
+
+## 📝 License
+
+This project is licensed under the terms specified in the LICENSE file.
+
+## 🚀 Future Enhancements
+
+- [ ] Support for multiple programming languages
+- [ ] Leaderboards and rankings
+- [ ] Custom challenge creation
+- [ ] Real-time multiplayer competitions
+- [ ] Performance analytics dashboard
+- [ ] Code quality metrics
+
+---
+
+**Happy coding and may the fastest coder win!** ⚡ 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# SP33D C0D3R
+
+SP33D C0D3R is a minimal viable product for a speed-oriented coding platform.
+Players race to solve programming challenges in the browser while the backend measures time to green across public and hidden tests.
+
+## Project layout
+
+- `api/` – FastAPI service providing user, run and leaderboard endpoints.
+- `runner/` – Dockerized language runners that execute public and hidden tests.
+- `challenges/` – Challenge bundles with prompts, starter code and tests.
+- `web/` – Next.js frontend with a Monaco editor and API proxy.
+- `infra/` – Database schema and other infrastructure files.
+
+## Development
+
+1. **Build the Python runner image**
+   ```bash
+   docker build -t sp33d-runner-python:latest runner/python
+   ```
+2. **Start the stack**
+   ```bash
+   docker compose up --build
+   ```
+3. **Seed a challenge** – insert at least one row into the `challenges` table (e.g. `fizzbuzz`).
+4. Open `http://localhost:3000/challenge/fizzbuzz` in a browser to play.
+
+## Testing
+
+Challenges ship with public tests to verify starter implementations. For example:
+```bash
+(cd challenges/fizzbuzz && PYTHONPATH=. pytest tests_public)
+```
+
+---
+
+Licensed under the MIT License. See `LICENSE` for details.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,179 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import psycopg2, os, docker, json
+
+app = FastAPI()
+dclient = docker.from_env()
+
+def db():
+    return psycopg2.connect(os.getenv("DATABASE_URL"))
+
+class NewUser(BaseModel):
+    handle: str
+
+class NewRun(BaseModel):
+    user_id: str
+    challenge_slug: str
+
+class AssistEvt(BaseModel):
+    chars: int
+
+class Attempt(BaseModel):
+    code: str
+
+class RunResult(BaseModel):
+    passed: bool
+    public_ok: bool
+    hidden_ok: bool
+    logs: dict
+
+@app.post("/users")
+def create_user(u: NewUser):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute("INSERT INTO users(handle) VALUES(%s) RETURNING id", (u.handle,))
+        return {"id": cur.fetchone()[0]}
+
+@app.post("/runs")
+def create_run(r: NewRun):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute("SELECT id, language FROM challenges WHERE slug=%s", (r.challenge_slug,))
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "challenge not found")
+        chal_id, lang = row
+        cur.execute("""INSERT INTO runs(user_id, challenge_id, details) VALUES(%s,%s,%s) RETURNING id""",
+                    (r.user_id, chal_id, json.dumps({})))
+        run_id = cur.fetchone()[0]
+    container = dclient.containers.run(
+        image="sp33d-runner-python:latest",
+        command=["/entrypoint.sh", run_id],
+        detach=True,
+        network_disabled=True,
+        mem_limit="512m",
+        volumes={
+            os.path.abspath(f"./challenges/{r.challenge_slug}"): {"bind": "/challenge", "mode": "ro"}
+        },
+    )
+    with db() as conn, conn.cursor() as cur:
+        cur.execute("UPDATE runs SET details = details || %s::jsonb WHERE id=%s",
+                    (json.dumps({"container_id": container.id}), run_id))
+    return {"run_id": run_id, "container_id": container.id}
+
+@app.post("/runs/{run_id}/assist")
+def assist(run_id: str, evt: AssistEvt):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE runs SET
+              assist_paste_events = assist_paste_events + 1,
+              assist_paste_chars = assist_paste_chars + %s
+            WHERE id=%s
+            """,
+            (evt.chars, run_id),
+        )
+        cur.execute(
+            """INSERT INTO events(run_id, kind, data) VALUES(%s,'assist_paste', %s::jsonb)""",
+            (run_id, json.dumps({"chars": evt.chars})),
+        )
+    return {"ok": True}
+
+@app.post("/runs/{run_id}/attempt")
+def attempt(run_id: str, req: Attempt):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute("SELECT details FROM runs WHERE id=%s", (run_id,))
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "run not found")
+        details = row[0]
+        container_id = details.get("container_id")
+        cur.execute("UPDATE runs SET attempts = attempts + 1 WHERE id=%s", (run_id,))
+        cur.execute("INSERT INTO events(run_id, kind) VALUES(%s,'attempt')", (run_id,))
+    if not container_id:
+        raise HTTPException(500, "container missing")
+    container = dclient.containers.get(container_id)
+    import io, tarfile
+    data = req.code.encode()
+    tarstream = io.BytesIO()
+    with tarfile.open(fileobj=tarstream, mode='w') as tar:
+        info = tarfile.TarInfo(name="starter.py")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    tarstream.seek(0)
+    container.put_archive("/workspace/challenge", tarstream.getvalue())
+    container.exec_run("touch /signals/attempt")
+    return {"ok": True}
+
+@app.post("/runs/{run_id}/result")
+def result(run_id: str, res: RunResult):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute("SELECT started_at, passed FROM runs WHERE id=%s", (run_id,))
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "run not found")
+        started_at, already = row
+        if res.passed and not already:
+            cur.execute(
+                """
+                UPDATE runs SET passed=true, finished_at=now(), wall_ms = EXTRACT(MILLISECONDS FROM now() - started_at), details = details || %s::jsonb WHERE id=%s
+                """,
+                (json.dumps({"logs": res.logs}), run_id),
+            )
+            cur.execute("INSERT INTO events(run_id, kind, data) VALUES(%s,'pass',%s::jsonb)", (run_id, json.dumps(res.dict())))
+        else:
+            cur.execute(
+                "UPDATE runs SET details = details || %s::jsonb WHERE id=%s",
+                (json.dumps({"logs": res.logs}), run_id),
+            )
+            cur.execute("INSERT INTO events(run_id, kind, data) VALUES(%s,'fail',%s::jsonb)", (run_id, json.dumps(res.dict())))
+    return {"ok": True}
+
+@app.get("/challenges/{slug}")
+def get_challenge(slug: str):
+    path = os.path.join("challenges", slug)
+    try:
+        with open(os.path.join(path, "prompt.md")) as f:
+            prompt = f.read()
+        with open(os.path.join(path, "starter.py")) as f:
+            starter = f.read()
+    except FileNotFoundError:
+        raise HTTPException(404, "challenge not found")
+    return {"prompt": prompt, "starter": starter}
+
+@app.get("/runs/{run_id}/tail")
+def tail(run_id: str):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute("SELECT passed, details FROM runs WHERE id=%s", (run_id,))
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "run not found")
+        passed, details = row
+    logs = details.get("logs", {})
+    return {"passed": passed, "logs": logs}
+
+@app.get("/leaderboard/{slug}")
+def leaderboard(slug: str):
+    with db() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT u.handle, r.wall_ms, r.attempts, r.assist_paste_events, r.assist_paste_chars
+            FROM runs r
+            JOIN users u ON u.id = r.user_id
+            JOIN challenges c ON c.id = r.challenge_id
+            WHERE c.slug=%s AND r.passed=true
+            ORDER BY r.wall_ms ASC, r.attempts ASC
+            LIMIT 20
+            """,
+            (slug,),
+        )
+        rows = cur.fetchall()
+    out = [
+        {
+            "handle": h,
+            "wall_ms": w,
+            "attempts": a,
+            "assist_paste_events": e,
+            "assist_paste_chars": ch,
+        }
+        for h, w, a, e, ch in rows
+    ]
+    return {"results": out}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+psycopg2-binary
+docker
+pydantic

--- a/challenges/fizzbuzz/manifest.yaml
+++ b/challenges/fizzbuzz/manifest.yaml
@@ -1,0 +1,5 @@
+slug: fizzbuzz
+title: "FizzBuzz with a twist"
+language: python
+version: 1
+time_cap_ms: 900000

--- a/challenges/fizzbuzz/prompt.md
+++ b/challenges/fizzbuzz/prompt.md
@@ -1,0 +1,5 @@
+Write function fizzbuzz(n) returning a list of 1..n with:
+- "Fizz" for multiples of 3
+- "Buzz" for multiples of 5
+- "FizzBuzz" for multiples of both
+- Integers otherwise

--- a/challenges/fizzbuzz/starter.py
+++ b/challenges/fizzbuzz/starter.py
@@ -1,0 +1,3 @@
+def fizzbuzz(n: int):
+    # TODO: implement
+    return []

--- a/challenges/fizzbuzz/tests_hidden/test_edges.py
+++ b/challenges/fizzbuzz/tests_hidden/test_edges.py
@@ -1,0 +1,5 @@
+from starter import fizzbuzz
+
+def test_large():
+    out = fizzbuzz(100)
+    assert out[2] == "Fizz" and out[4] == "Buzz" and out[14] == "FizzBuzz"

--- a/challenges/fizzbuzz/tests_public/test_basic.py
+++ b/challenges/fizzbuzz/tests_public/test_basic.py
@@ -1,0 +1,4 @@
+from starter import fizzbuzz
+
+def test_small():
+    assert fizzbuzz(5) == [1,2,"Fizz",4,"Buzz"]

--- a/challenges/two_sum/manifest.yaml
+++ b/challenges/two_sum/manifest.yaml
@@ -1,0 +1,5 @@
+slug: two-sum
+title: "Two Sum"
+language: python
+version: 1
+time_cap_ms: 900000

--- a/challenges/two_sum/prompt.md
+++ b/challenges/two_sum/prompt.md
@@ -1,0 +1,2 @@
+Given a list of integers and a target, return indices of the two numbers that add up to the target.
+Return the indices in ascending order.

--- a/challenges/two_sum/starter.py
+++ b/challenges/two_sum/starter.py
@@ -1,0 +1,3 @@
+def two_sum(nums, target):
+    # TODO: implement
+    return []

--- a/challenges/two_sum/tests_hidden/test_edges.py
+++ b/challenges/two_sum/tests_hidden/test_edges.py
@@ -1,0 +1,5 @@
+from starter import two_sum
+
+def test_negative():
+    res = two_sum([-1,-2,-3,-4,-5], -8)
+    assert res == [2,4]

--- a/challenges/two_sum/tests_public/test_basic.py
+++ b/challenges/two_sum/tests_public/test_basic.py
@@ -1,0 +1,4 @@
+from starter import two_sum
+
+def test_example():
+    assert two_sum([2,7,11,15], 9) == [0,1]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   db:
     image: postgres:15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: speed
+      POSTGRES_USER: speed
+      POSTGRES_DB: speed
+    volumes:
+      - "./infra/init.sql:/docker-entrypoint-initdb.d/init.sql:ro"
+    ports:
+      - "5432:5432"
+
+  api:
+    build: ./api
+    environment:
+      DATABASE_URL: postgres://speed:speed@db:5432/speed
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    volumes:
+      - "./challenges:/app/challenges:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  web:
+    build: ./web
+    depends_on:
+      - api
+    environment:
+      NEXT_PUBLIC_API_BASE: http://localhost:8000
+    ports:
+      - "3000:3000"
+
+  runner_base_python:
+    build: ./runner/python
+    image: sp33d-runner-python:latest

--- a/infra/init.sql
+++ b/infra/init.sql
@@ -1,0 +1,38 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE TABLE users(
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  handle TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE challenges(
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  language TEXT NOT NULL,
+  version INT NOT NULL DEFAULT 1,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE runs(
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
+  challenge_id UUID NOT NULL REFERENCES challenges(id),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at TIMESTAMPTZ,
+  passed BOOLEAN NOT NULL DEFAULT FALSE,
+  attempts INT NOT NULL DEFAULT 0,
+  hints_used INT NOT NULL DEFAULT 0,
+  wall_ms INT,
+  assist_paste_events INT NOT NULL DEFAULT 0,
+  assist_paste_chars INT NOT NULL DEFAULT 0,
+  details JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE events(
+  id BIGSERIAL PRIMARY KEY,
+  run_id UUID NOT NULL REFERENCES runs(id),
+  ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+  kind TEXT NOT NULL,
+  data JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX events_run_ts ON events(run_id, ts);

--- a/runner/python/Dockerfile
+++ b/runner/python/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+RUN pip install pytest pytest-timeout requests
+WORKDIR /workspace
+COPY run_tests.py /run_tests.py
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+RUN mkdir -p /signals
+ENTRYPOINT ["/entrypoint.sh"]

--- a/runner/python/entrypoint.sh
+++ b/runner/python/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+RUN_ID="$1"
+cp -r /challenge /workspace/challenge
+cd /workspace/challenge
+
+echo "Ready" > /signals/status
+while true; do
+  if [ -f /signals/attempt ]; then
+    rm -f /signals/attempt
+    python /run_tests.py "$RUN_ID" || true
+  fi
+  sleep 0.5
+done

--- a/runner/python/run_tests.py
+++ b/runner/python/run_tests.py
@@ -1,0 +1,27 @@
+import json, os, subprocess, sys, time, requests
+
+API = os.getenv("API_URL", "http://api:8000")
+run_id = sys.argv[1]
+
+def _run(cmd):
+    start = time.time()
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    return p.returncode == 0, time.time() - start, p.stdout
+
+ok_pub, dt_pub, log_pub = _run(["pytest", "-q", "tests_public", "--maxfail=1", "--disable-warnings"])
+ok_hid, dt_hid, log_hid = _run(["pytest", "-q", "tests_hidden", "--maxfail=1", "--disable-warnings"])
+
+passed = ok_pub and ok_hid
+payload = {
+    "passed": passed,
+    "public_ok": ok_pub,
+    "hidden_ok": ok_hid,
+    "logs": {
+        "public": log_pub[-4000:],
+        "hidden": (log_hid[-4000:] if passed else "redacted until pass"),
+    },
+}
+try:
+    requests.post(f"{API}/runs/{run_id}/result", json=payload, timeout=5)
+except Exception as e:
+    print("warn: result post failed", e)

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm","run","dev"]

--- a/web/app/api/[...path]/route.ts
+++ b/web/app/api/[...path]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000";
+
+async function handler(req: NextRequest, { params }: { params: { path: string[] } }) {
+  const url = `${API_BASE}/${params.path.join("/")}${req.nextUrl.search}`;
+  const init: RequestInit = {
+    method: req.method,
+    headers: req.headers as any,
+    body: req.method !== "GET" && req.method !== "HEAD" ? await req.text() : undefined,
+  };
+  const resp = await fetch(url, init);
+  const body = await resp.text();
+  return new NextResponse(body, { status: resp.status, headers: resp.headers });
+}
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const DELETE = handler;

--- a/web/app/challenge/[slug]/page.tsx
+++ b/web/app/challenge/[slug]/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import Editor from "@monaco-editor/react";
+
+export default function ChallengePage({ params }: { params: { slug: string } }) {
+  const [prompt, setPrompt] = useState<string>("");
+  const [code, setCode] = useState<string>("");
+  const [runId, setRunId] = useState<string>("");
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [logs, setLogs] = useState<string>("");
+  const pasteCharsRef = useRef<number>(0);
+
+  useEffect(() => {
+    (async () => {
+      const me = await fetch("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle: "anon" })
+      }).then(r => r.json());
+      const p = await fetch(`/api/challenges/${params.slug}`).then(r => r.json());
+      setPrompt(p.prompt);
+      setCode(p.starter);
+      const run = await fetch("/api/runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user_id: me.id, challenge_slug: params.slug })
+      }).then(r => r.json());
+      setRunId(run.run_id);
+      setStartedAt(Date.now());
+    })();
+  }, [params.slug]);
+
+  useEffect(() => {
+    if (!startedAt) return;
+    const id = setInterval(() => setTimer(Date.now() - startedAt), 100);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  function onEditorMount(editor: any) {
+    editor.onDidPaste((e: any) => {
+      const chars = e.range.endColumn - e.range.startColumn;
+      pasteCharsRef.current += Math.max(chars, 0);
+      fetch(`/api/runs/${runId}/assist`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chars })
+      }).catch(() => {});
+    });
+  }
+
+  async function onRun() {
+    await fetch(`/api/runs/${runId}/attempt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code })
+    });
+    const res = await fetch(`/api/runs/${runId}/tail`).then(r => r.json());
+    setLogs((res.logs?.public || "") + "\n" + (res.passed ? "ALL TESTS GREEN" : ""));
+    if (res.passed) alert("🎉 Passed! Time: " + (timer / 1000).toFixed(2) + "s");
+  }
+
+  return (
+    <div className="p-6 grid grid-cols-2 gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold mb-2">{params.slug}</h1>
+        <p className="mb-4 whitespace-pre-wrap">{prompt}</p>
+        <div className="text-sm opacity-70 mb-2">Time: {(timer / 1000).toFixed(2)}s</div>
+        <Editor
+          height="60vh"
+          defaultLanguage="python"
+          value={code}
+          onChange={v => setCode(v || "")}
+          onMount={onEditorMount}
+          options={{ fontSize: 14, minimap: { enabled: false } }}
+        />
+        <button onClick={onRun} className="mt-3 px-4 py-2 rounded bg-black text-white">
+          Run tests
+        </button>
+      </div>
+      <pre className="bg-neutral-100 p-4 rounded overflow-auto h-[75vh]">{logs || "Logs..."}</pre>
+    </div>
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>SP33D C0D3R</div>;
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+// NOTE: This file should not be edited

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+}
+module.exports = nextConfig

--- a/web/package.json
+++ b/web/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@monaco-editor/react": "^4.4.6",
-    "next": "13.5.0",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "@monaco-editor/react": "^4.6.0",
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sp33d-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@monaco-editor/react": "^4.4.6",
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Implement FastAPI backend with attempt and result endpoints and leaderboard
- Add runner container scripts for executing tests and reporting results
- Introduce FizzBuzz and Two Sum challenges with public/hidden tests and Next.js frontend proxy

## Testing
- `python -m py_compile api/main.py runner/python/run_tests.py`
- `(cd challenges/fizzbuzz && PYTHONPATH=. pytest tests_public)` *(fails: TODO implementation)*
- `(cd challenges/two_sum && PYTHONPATH=. pytest tests_public)` *(fails: TODO implementation)*

------
https://chatgpt.com/codex/tasks/task_b_68a15a9ab3f883239706877ed054dda6